### PR TITLE
Look for new community efforts on locally hosted (a.k.a. private) registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ spec:
 
 If, for example, you wanted to use NFS you would just need to change the
 `gcePersistentDisk` block to `nfs`. See
-[here](../../../docs/user-guide/volumes.md) for more details on volumes.
+[here](https://kubernetes.io/docs/user-guide/volumes.md) for more details on volumes.
 
 Note that in any case, the storage (in the case the GCE PersistentDisk) must be
 created independently - this is not something Kubernetes manages for you (yet).
@@ -105,18 +105,18 @@ metadata:
   name: kube-registry-v0
   namespace: kube-system
   labels:
-    k8s-app: kube-registry
+    k8s-app: kube-registry-upstream
     version: v0
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: 1
   selector:
-    k8s-app: kube-registry
+    k8s-app: kube-registry-upstream
     version: v0
   template:
     metadata:
       labels:
-        k8s-app: kube-registry
+        k8s-app: kube-registry-upstream
         version: v0
         kubernetes.io/cluster-service: "true"
     spec:
@@ -158,12 +158,12 @@ metadata:
   name: kube-registry
   namespace: kube-system
   labels:
-    k8s-app: kube-registry
+    k8s-app: kube-registry-upstream
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "KubeRegistry"
 spec:
   selector:
-    k8s-app: kube-registry
+    k8s-app: kube-registry-upstream
   ports:
   - name: registry
     port: 5000
@@ -185,14 +185,14 @@ metadata:
   name: kube-registry-proxy
   namespace: kube-system
   labels:
-    k8s-app: kube-registry
+    k8s-app: kube-registry-proxy
     kubernetes.io/cluster-service: "true"
     version: v0.4
 spec:
   template:
     metadata:
       labels:
-        k8s-app: kube-registry
+        k8s-app: kube-registry-proxy
         kubernetes.io/name: "kube-registry-proxy"
         kubernetes.io/cluster-service: "true"
         version: v0.4
@@ -215,6 +215,12 @@ spec:
           hostPort: 5000
 ```
 <!-- END MUNGE: EXAMPLE ../../saltbase/salt/kube-registry-proxy/kube-registry-proxy.yaml -->
+
+When modifying replication-controller, service and daemon-set defintions, take
+care to ensure _unique_ identifiers for the rc-svc couple and the daemon-set.
+Failing to do so will have register the localhost proxy daemon-sets to the
+upstream service. As a result they will then try to proxy themselves, which
+will, for obvious reasons, not work.
 
 This ensures that port 5000 on each node is directed to the registry `Service`.
 You should be able to verify that it is running by hitting port 5000 with a web
@@ -243,7 +249,7 @@ You can use `kubectl` to set up a port-forward from your local node to a
 running Pod:
 
 ```console
-$ POD=$(kubectl get pods --namespace kube-system -l k8s-app=kube-registry \
+$ POD=$(kubectl get pods --namespace kube-system -l k8s-app=kube-registry-upstream \
             -o template --template '{{range .items}}{{.metadata.name}} {{.status.phase}}{{"\n"}}{{end}}' \
             | grep Running | head -1 | cut -f1 -d' ')
 

--- a/auth/README.md
+++ b/auth/README.md
@@ -83,7 +83,7 @@ Setup proxy or port-forwarding to the kube-registry. Image push/pull should fail
 
 ### Configure Nodes to Authenticate with Kube-Registry
 
-By default, nodes assume no authentication is required by kube-registry. Without authentication, nodes cannot pull images from kube-registry. To solve this, more documentation can be found [Here](https://github.com/kubernetes/kubernetes/blob/master/docs/user-guide/images.md#configuring-nodes-to-authenticate-to-a-private-repository)
+By default, nodes assume no authentication is required by kube-registry. Without authentication, nodes cannot pull images from kube-registry. To solve this, more documentation can be found [Here](https://github.com/kubernetes/kubernetes.github.io/blob/master/docs/concepts/containers/images.md#configuring-nodes-to-authenticate-to-a-private-repository).
 
 
 

--- a/registry-rc.yaml
+++ b/registry-rc.yaml
@@ -4,19 +4,19 @@ metadata:
   name: kube-registry-v0
   namespace: kube-system
   labels:
-    k8s-app: kube-registry
+    k8s-app: kube-registry-upstream
     version: v0
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   replicas: 1
   selector:
-    k8s-app: kube-registry
+    k8s-app: kube-registry-upstream
     version: v0
   template:
     metadata:
       labels:
-        k8s-app: kube-registry
+        k8s-app: kube-registry-upstream
         version: v0
         kubernetes.io/cluster-service: "true"
     spec:

--- a/registry-svc.yaml
+++ b/registry-svc.yaml
@@ -4,13 +4,13 @@ metadata:
   name: kube-registry
   namespace: kube-system
   labels:
-    k8s-app: kube-registry
+    k8s-app: kube-registry-upstream
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
     kubernetes.io/name: "KubeRegistry"
 spec:
   selector:
-    k8s-app: kube-registry
+    k8s-app: kube-registry-upstream
   ports:
   - name: registry
     port: 5000


### PR DESCRIPTION
After https://github.com/kubernetes/kubernetes/issues/49213 through https://github.com/kubernetes/kubernetes/commits/master/cluster/addons/registry

Found https://github.com/kubernetes-incubator/kubespray/pull/2244

There's also the very targeted, but still maintained, https://github.com/kubernetes/minikube/tree/master/deploy/addons/registry

The reason I'm looking is https://github.com/knative/serving/issues/23 -- Source-to-URLs workflow currently require the user to understand image URLs and often Docker registry authentication.

